### PR TITLE
Move to current ros2_control launching and controller

### DIFF
--- a/moveit_ros/hybrid_planning/test/config/demo_controller.yaml
+++ b/moveit_ros/hybrid_planning/test/config/demo_controller.yaml
@@ -5,21 +5,14 @@ controller_manager:
       type: joint_trajectory_controller/JointTrajectoryController
     joint_state_controller:
       type: joint_state_controller/JointStateController
-    panda_joint_group_position_controller:
-      type: position_controllers/JointGroupPositionController
 
 panda_arm_controller:
   ros__parameters:
-    joints:
-      - panda_joint1
-      - panda_joint2
-      - panda_joint3
-      - panda_joint4
-      - panda_joint5
-      - panda_joint6
-      - panda_joint7
-panda_joint_group_position_controller:
-  ros__parameters:
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
     joints:
       - panda_joint1
       - panda_joint2

--- a/moveit_ros/hybrid_planning/test/config/servo_solver.yaml
+++ b/moveit_ros/hybrid_planning/test/config/servo_solver.yaml
@@ -56,14 +56,14 @@ command_out_topic: /panda_joint_group_position_controller/commands # Publish out
 
 ## Collision checking for the entire robot body
 check_collisions: true # Check collisions?
-collision_check_rate: 10.0 # [Hz] Collision-checking can easily bog down a CPU if done too often.
+collision_check_rate: 20.0 # [Hz] Collision-checking can easily bog down a CPU if done too often.
 # Two collision check algorithms are available:
 # "threshold_distance" begins slowing down when nearer than a specified distance. Good if you want to tune collision thresholds manually.
 # "stop_distance" stops if a collision is nearer than the worst-case stopping distance and the distance is decreasing. Requires joint acceleration limits
 collision_check_type: threshold_distance
 # Parameters for "threshold_distance"-type collision checking
 self_collision_proximity_threshold: 0.01 # Start decelerating when a self-collision is this far [m]
-scene_collision_proximity_threshold: 0.02 # Start decelerating when a scene collision is this far [m]
+scene_collision_proximity_threshold: 0.005 # Start decelerating when a scene collision is this far [m]
 # Parameters for "stop_distance"-type collision checking
 collision_distance_safety_factor: 1000.0 # Must be >= 1. A large safety factor is recommended to account for latency
 min_allowable_collision_distance: 0.01 # Stop if a collision is closer than this [m]

--- a/moveit_ros/hybrid_planning/test/config/servo_solver.yaml
+++ b/moveit_ros/hybrid_planning/test/config/servo_solver.yaml
@@ -18,11 +18,11 @@ low_latency_mode: false  # Set this to true to publish as soon as an incoming Tw
 
 # What type of topic does your robot driver expect?
 # Currently supported are std_msgs/Float64MultiArray or trajectory_msgs/JointTrajectory
-command_out_type: std_msgs/Float64MultiArray
+command_out_type: trajectory_msgs/JointTrajectory
 
 # What to publish? Can save some bandwidth as most robots only require positions or velocities
 publish_joint_positions: true
-publish_joint_velocities: false
+publish_joint_velocities: true
 publish_joint_accelerations: false
 
 ## Incoming Joint State properties
@@ -52,7 +52,7 @@ cartesian_command_in_topic: ~/delta_twist_cmds  # Topic for incoming Cartesian t
 joint_command_in_topic: ~/delta_joint_cmds # Topic for incoming joint angle commands
 joint_topic: /joint_states
 status_topic: ~/status # Publish status to this topic
-command_out_topic: /panda_joint_group_position_controller/commands # Publish outgoing commands here
+command_out_topic: /panda_arm_controller/joint_trajectory # Publish outgoing commands here
 
 ## Collision checking for the entire robot body
 check_collisions: true # Check collisions?

--- a/moveit_ros/hybrid_planning/test/launch/hybrid_planning.launch.py
+++ b/moveit_ros/hybrid_planning/test/launch/hybrid_planning.launch.py
@@ -174,33 +174,19 @@ def generate_launch_description():
         },
     )
 
-    # load joint_state_controller
-    load_joint_state_controller = ExecuteProcess(
-        cmd=["ros2 control load_start_controller joint_state_controller"],
-        shell=True,
-        output="screen",
-    )
-    load_controllers = [load_joint_state_controller]
-
-    # load panda_arm_controller
-    load_controllers += [
-        ExecuteProcess(
-            cmd=[
-                "ros2 control load_configure_controller panda_joint_group_position_controller"
-            ],
-            shell=True,
-            output="screen",
-            on_exit=[
-                ExecuteProcess(
-                    cmd=[
-                        "ros2 control switch_controllers --start-controllers panda_joint_group_position_controller"
-                    ],
-                    shell=True,
-                    output="screen",
-                )
-            ],
-        )
-    ]
+    # Load controllers
+    load_controllers = []
+    for controller in [
+        "joint_state_controller",
+        "panda_joint_group_position_controller",
+    ]:
+        load_controllers += [
+            ExecuteProcess(
+                cmd=["ros2 run controller_manager spawner.py {}".format(controller)],
+                shell=True,
+                output="screen",
+            )
+        ]
 
     # Test node
     test_request_node = Node(

--- a/moveit_ros/hybrid_planning/test/launch/hybrid_planning.launch.py
+++ b/moveit_ros/hybrid_planning/test/launch/hybrid_planning.launch.py
@@ -178,7 +178,7 @@ def generate_launch_description():
     load_controllers = []
     for controller in [
         "joint_state_controller",
-        "panda_joint_group_position_controller",
+        "panda_arm_controller",
     ]:
         load_controllers += [
             ExecuteProcess(


### PR DESCRIPTION
### Description

A small one, just launches the panda controller like the rest of the MoveIt demos and tutorials do. This involved switching the output from Servo.

I also played around a little bit with the Servo collision parameters - making the collision checking run faster and letting it get closer to objects before it considered a collision dangerous. I think (?) it had a little improvement on using Servo for the local planner, let me know what you think.

One note, now the `demo_controller.yaml` config file is very close to the one in the Panda moveit config package that the other demos use, so unless you really want that 500 hz rate, maybe switch the launch files to point to the other file and delete this one?